### PR TITLE
Enable C++11 when compiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Get the source code.
 
 Compile the source code using this command (all one line):
 
-    g++ -o untrunc -O3 *.cpp -lavformat -lavcodec -lavutil
+    g++ -o untrunc -O3 *.cpp -lavformat -lavcodec -lavutil -std=c++11
 
 
 ## Using


### PR DESCRIPTION
In Ubuntu 16.04 the buillding instructions were throwing an error:

> This file requires compiler and library support for the ISO C++ 2011 standard

This PR fixed the problem at least for my particular case.