### PR TITLE
Added missing flag for ffmpeg-3.3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ else
   LDFLAGS += -Lffmpeg-$(FF_VER)/libavutil -lavutil
   #LDFLAGS += -Lffmpeg-$(FF_VER)/libswscale/ -lswresample
   #LDFLAGS += -Lffmpeg-$(FF_VER)/libavresample -lavresample
-  LDFLAGS += -lpthread -lz -lbz2 -lX11 -ldl -lva -lva-drm -lva-x11 -llzma
+  LDFLAGS += -lpthread -lz -lbz2 -lX11 -ldl -lva -lva-drm -lva-x11 -llzma -lvdpau
 endif
 
 CXXFLAGS += -std=c++11 -g

--- a/file.cpp
+++ b/file.cpp
@@ -51,7 +51,7 @@ bool FileRead::open(string filename) {
 	if(file_ == NULL) return false;
 
 	fseeko(file_, 0L, SEEK_END);
-	size_ = ftello(file_);
+	size_ = ftello64(file_);
 	fseeko(file_, 0L, SEEK_SET);
 
 	buffer_ = (uchar*) malloc(buf_size_);
@@ -116,7 +116,7 @@ size_t FileRead::readBuffer(uchar* dest, size_t size, size_t n) {
 		if (total >= to_uint(buf_size_)){
 			size_t x = fread(dest+nread, 1, total, file_);
 			nread += x;
-			fillBuffer(ftello(file_));
+			fillBuffer(ftello64(file_));
 		} else {
 			size_t x = min(fillBuffer(buf_begin_+buf_off_), total);
 			memcpy(dest+nread, buffer_, x);
@@ -198,7 +198,7 @@ const uchar* FileRead::getPtrAt(off64_t pos, int size_requested) {
 }
 
 off64_t FileWrite::pos() {
-	return ftell(file_);
+	return ftello64(file_);
 }
 
 int FileWrite::writeInt(int n) {


### PR DESCRIPTION
`make FF_VER=3.3.9` fails with 

```
g++ .build_3.3.9/track.o .build_3.3.9/codec.o .build_3.3.9/atom.o .build_3.3.9/common.o .build_3.3.9/sps-info.o .build_3.3.9/mp4.o .build_3.3.9/nal-slice.o .build_3.3.9/nal.o .build_3.3.9/main.o .build_3.3.9/avc-config.o .build_3.3.9/file.o -Lffmpeg-3.3.9/libavformat -lavformat -Lffmpeg-3.3.9/libavcodec -lavcodec -Lffmpeg-3.3.9/libavutil -lavutil -lpthread -lz -lbz2 -lX11 -ldl -lva -lva-drm -lva-x11 -llzma -o untrunc
/usr/bin/ld: ffmpeg-3.3.9/libavutil/libavutil.a(hwcontext_vdpau.o): in function `vdpau_device_create':
/home/user/untrunc/ffmpeg-3.3.9/libavutil/hwcontext_vdpau.c:439: undefined reference to `vdp_device_create_x11'
collect2: error: ld returned 1 exit status
make: *** [Makefile:87: untrunc] Error 1
```