### PR TITLE
untrunk uses MacOSx incompatible assert()

### DIFF
--- a/src/atom.cpp
+++ b/src/atom.cpp
@@ -467,7 +467,7 @@ void BufferedAtom::write(FileWrite &output, bool force_64) {
 			offset += to_skip_it->second;
 			to_skip_it++;
 			assert(at_end(to_skip_it) || to_skip_it->first > (to_skip_it-1)->first);
-			assert(offset <= contentSize(), offset, contentSize(), offset-contentSize());
+			//assert(offset <= contentSize(), offset, contentSize(), offset-contentSize());
 		}
 	}
 

--- a/src/codec.cpp
+++ b/src/codec.cpp
@@ -66,9 +66,9 @@ void Codec::initOnce() {
 }
 
 Track* Codec::getTrack() {
-	assert(track_idx_ >= 0, track_idx_);
+	//assert(track_idx_ >= 0, track_idx_);
 	auto r = &g_mp4->tracks_[track_idx_];
-	assert(r->codec_.name_ == name_, track_idx_, r->codec_.name_, name_);
+	//assert(r->codec_.name_ == name_, track_idx_, r->codec_.name_, name_);
 	return r;
 }
 

--- a/src/mp4.h
+++ b/src/mp4.h
@@ -267,7 +267,7 @@ private:
 			start = last_end;
 			length -= already_skipped;
 		}
-		assert(length >= 0, length);
+		//assert(length >= 0, length);
 	}
 
 	int64_t calcStep(off_t offset);

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -516,7 +516,7 @@ void Track::saveSampleToChunk() {
 }
 
 void Track::saveChunkOffsets() {
-	assert(chunks_[0].off_ >= 0, codec_.name_, chunks_[0].off_);
+	//assert(chunks_[0].off_ >= 0, codec_.name_, chunks_[0].off_);
 
 	Atom *co64 = trak_->atomByName("co64");
 	if (co64) {


### PR DESCRIPTION
when compiling untrunk on Mac OS X 15.5 Sequoia, I got the following errors, caused by MacOSx using assert() that is incompatible with the format untrunk uses. This fix just comments away the rogue assert calls to make untrunk compilable. This probably isn't the right fix for this issue, but maybe it will help someone.

Compile errors:
```
untrunc: v367-13cafed
ffmpeg: 6.0

c++ -MMD -MP -DUNTR_VERSION=\"v367-13cafed\" -isystem./ffmpeg-6.0 -std=c++17 -D_FILE_OFFSET_BITS=64 -g -o .build_6.0/src/atom.o -c src/atom.cpp
In file included from src/atom.cpp:4:
src/mp4.h:270:23: error: too many arguments provided to function-like macro invocation
  270 |                 assert(length >= 0, length);
      |                                     ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/assert.h:74:9: note: macro 'assert' defined here
   74 | #define assert(e) \
      |         ^
In file included from src/atom.cpp:4:
src/mp4.h:270:3: error: use of undeclared identifier 'assert'
  270 |                 assert(length >= 0, length);
      |                 ^
src/atom.cpp:470:36: error: too many arguments provided to function-like macro invocation
  470 |                         assert(offset <= contentSize(), offset, contentSize(), offset-contentSize());
      |                                                         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/assert.h:74:9: note: macro 'assert' defined here
   74 | #define assert(e) \
      |         ^
src/atom.cpp:470:4: error: use of undeclared identifier 'assert'
  470 |                         assert(offset <= contentSize(), offset, contentSize(), offset-contentSize());
      |                         ^
4 errors generated.




c++ -MMD -MP -DUNTR_VERSION=\"v367-13cafed-dirty\" -isystem./ffmpeg-6.0 -std=c++17 -D_FILE_OFFSET_BITS=64 -g -o .build_6.0/src/atom.o -c src/atom.cpp
src/atom.cpp:470:36: error: too many arguments provided to function-like macro invocation
  470 |                         assert(offset <= contentSize(), offset, contentSize(), offset-contentSize());
      |                                                         ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/assert.h:74:9: note: macro 'assert' defined here
   74 | #define assert(e) \
      |         ^
src/atom.cpp:470:4: error: use of undeclared identifier 'assert'
  470 |                         assert(offset <= contentSize(), offset, contentSize(), offset-contentSize());
      |                         ^
2 errors generated.
make: *** [.build_6.0/src/atom.o] Error 1

src/codec.cpp:69:26: error: too many arguments provided to function-like macro invocation
   69 |         assert(track_idx_ >= 0, track_idx_);
      |                                 ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/assert.h:74:9: note: macro 'assert' defined here
   74 | #define assert(e) \
      |         ^
src/codec.cpp:69:2: error: use of undeclared identifier 'assert'
   69 |         assert(track_idx_ >= 0, track_idx_);
      |         ^
src/codec.cpp:71:35: error: too many arguments provided to function-like macro invocation
   71 |         assert(r->codec_.name_ == name_, track_idx_, r->codec_.name_, name_);
      |                                          ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/assert.h:74:9: note: macro 'assert' defined here
   74 | #define assert(e) \
      |         ^
src/codec.cpp:71:2: error: use of undeclared identifier 'assert'
   71 |         assert(r->codec_.name_ == name_, track_idx_, r->codec_.name_, name_);
      |         ^
4 errors generated.
make: *** [.build_6.0/src/codec.o] Error 1

c++ -MMD -MP -DUNTR_VERSION=\"v367-13cafed-dirty\" -isystem./ffmpeg-6.0 -std=c++17 -D_FILE_OFFSET_BITS=64 -g -o .build_6.0/src/track.o -c src/track.cpp
src/track.cpp:519:31: error: too many arguments provided to function-like macro invocation
  519 |         assert(chunks_[0].off_ >= 0, codec_.name_, chunks_[0].off_);
      |                                      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/assert.h:74:9: note: macro 'assert' defined here
   74 | #define assert(e) \
      |         ^
src/track.cpp:519:2: error: use of undeclared identifier 'assert'
  519 |         assert(chunks_[0].off_ >= 0, codec_.name_, chunks_[0].off_);
      |         ^
2 errors generated.
```

Content of /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/assert.h
```
#include <sys/cdefs.h>
#ifdef __cplusplus
#include <stdlib.h>
#endif /* __cplusplus */

/*
 * Unlike other ANSI header files, <assert.h> may usefully be included
 * multiple times, with and without NDEBUG defined.
 */

#undef assert

#ifdef NDEBUG
#define assert(e)       ((void)0)
#else

#include <_assert.h>

#ifdef __FILE_NAME__
#define __ASSERT_FILE_NAME __FILE_NAME__
#else /* __FILE_NAME__ */
#define __ASSERT_FILE_NAME __FILE__
#endif /* __FILE_NAME__ */

#ifndef __GNUC__

#define assert(e)  \
    ((void) ((e) ? ((void)0) : __assert (#e, __ASSERT_FILE_NAME, __LINE__)))

#else /* __GNUC__ */

#if __DARWIN_UNIX03
#define assert(e) \
    (__builtin_expect(!(e), 0) ? __assert_rtn(__func__, __ASSERT_FILE_NAME, __LINE__, #e) : (void)0)
#else /* !__DARWIN_UNIX03 */
#define assert(e)  \
    (__builtin_expect(!(e), 0) ? __assert (#e, __ASSERT_FILE_NAME, __LINE__) : (void)0)
#endif /* __DARWIN_UNIX03 */

#endif /* __GNUC__ */
#endif /* NDEBUG */

#include <_static_assert.h>
```