### PR TITLE
Track: Avoid reading zero-length vector in saveChunkOffsets()

### DIFF
--- a/src/track.cpp
+++ b/src/track.cpp
@@ -516,6 +516,8 @@ void Track::saveSampleToChunk() {
 }
 
 void Track::saveChunkOffsets() {
+	if (!chunks_.size()) return;
+
 	assert(chunks_[0].off_ >= 0, codec_.name_, chunks_[0].off_);
 
 	Atom *co64 = trak_->atomByName("co64");


### PR DESCRIPTION
This should fix an assertion when trying to recover videos with some completely missing tracks

Fixes #207 
Fixes #216 