### PR TITLE
Add Sony RSV file recovery support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This fork improves the [original](https://github.com/ponchio/untrunc) in the fol
 * compatible with new versions of ffmpeg
 * handles invalid atom lengths
 * supports GoPro and Sony XAVC videos
+* supports Sony RSV (Recording in progreSs Video) file recovery
 * many bugs got fixed, actively maintained
 
 ## Building
@@ -108,6 +109,18 @@ Then it should churn away and hopefully produce a playable file called `broken-v
 That's it you're done!
 
 (Thanks to Tom Sparrow for providing the guide)
+
+### Sony RSV Files
+
+Untrunc can recover Sony RSV files (incomplete/corrupted video files with the `.rsv` extension) created when recording is interrupted unexpectedly (e.g., power loss, card removal). These files contain raw video data but lack the proper container structure. RSV files are automatically detected, or you can force RSV mode with the `-rsv` flag:
+
+```shell
+./untrunc /path/to/reference.mp4 /path/to/corrupt.RSV
+# or explicitly:
+./untrunc -rsv /path/to/reference.mp4 /path/to/corrupt.RSV
+```
+
+RSV recovery supports both H.264/AVC and H.265/HEVC codecs, and automatically detects GOP structure parameters. See [RSV_FILE_FORMAT.md](RSV_FILE_FORMAT.md) for detailed format documentation.
 
 
 ### Help/Support

--- a/RSV_FILE_FORMAT.md
+++ b/RSV_FILE_FORMAT.md
@@ -1,0 +1,318 @@
+# Sony RSV File Format Documentation
+
+This document describes the Sony RSV file format based on reverse engineering efforts during the development of RSV recovery functionality for untrunc.
+
+## Overview
+
+RSV files are incomplete or corrupted video files created by Sony cameras (e.g., Sony FX3) when recording is interrupted unexpectedly (power loss, card removal, etc.). The `.rsv` file extension denotes a reserved, backup, or temporary file that contains raw video data but lacks the proper container structure (like MP4 or MXF) needed for playback. Despite being incomplete, RSV files contain valid video and audio data; they simply lack the proper MP4 container structure (moov atom) needed for playback.
+
+Unlike standard MP4 files which use interleaved chunks, RSV files use a **GOP-based block structure** where all components of a GOP (Group of Pictures) are stored contiguously.
+
+## File Structure
+
+### High-Level Layout
+
+```
+[GOP 0][GOP 1][GOP 2]...[GOP N][incomplete data]
+```
+
+Each GOP contains three sections in order:
+1. **rtmd block** - Timed metadata (variable packet count, typically 12 packets)
+2. **Video essence** - H.264/AVC or H.265/HEVC video frames (frame count detected from first GOP, assumed constant)
+3. **Audio essence** - PCM audio samples (size calculated once from first GOP's frame count, reused for all GOPs)
+
+### GOP Structure Detail
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         GOP N                               │
+├─────────────────┬──────────────────────┬───────────────────-┤
+│   rtmd Block    │    Video Frames      │   Audio Chunk      │
+│   Variable size │    Variable size     │   Variable size    │
+│   (N × packet)  │    (variable count)  │   (calculated)     │
+└─────────────────┴──────────────────────┴───────────────────-┘
+```
+
+**Typical values** (for 12-frame GOP at 25fps):
+- rtmd block: ~233,472 bytes (12 packets × 19,456 bytes)
+- Video frames: ~5-6 MB (12 frames, variable size)
+- Audio chunk: ~92,160 bytes (calculated from GOP duration)
+
+## rtmd Block (Timed Metadata)
+
+### Structure
+- **Total size**: Variable (depends on packet count and packet size)
+- **Packet count**: Usually 12 packets per GOP (can vary, observed 9-20)
+- **Packet size**: Typically 19,456 bytes each (auto-detected from file)
+
+### Packet Header Format
+
+Each rtmd packet has a 12-byte header structure:
+
+```
+Offset:  0  1  2  3  4  5  6  7  8  9 10 11
+Bytes:  00 1c 01 00 ?? ?? ?? ?? f0 01 00 10
+        ├──────────┤ ├────────┤ ├─────────┤
+         Prefix      Variable   Sony tag
+         (constant)  metadata   (constant)
+```
+
+| Offset | Bytes | Description |
+|--------|-------|-------------|
+| 0-3 | `00 1c 01 00` | Constant prefix (identifies rtmd packet type) |
+| 4-7 | variable | Camera metadata (timecode, frame counter, etc.) |
+| 8-11 | `f0 01 00 10` | Sony-specific tag (constant across all packets) |
+
+### Identifying Real rtmd Packets
+
+**Important**: The 4-byte prefix `00 1c 01 00` can appear randomly in video/audio data as false positives. To reliably identify real rtmd packets, verify **both**:
+
+1. Bytes 0-3 match `00 1c 01 00` (prefix)
+2. Bytes 8-11 match `f0 01 00 10` (Sony tag)
+
+**Observed header variants** (bytes 4-7 vary):
+```
+001c0100 230328e1 f0010010...  (most common)
+001c0100 22f728ed f0010010...  (variant)
+001c0100 230f28d5 f0010010...  (variant)
+```
+
+### Content
+The rtmd data contains camera metadata such as:
+- Timecode information
+- Recording parameters  
+- Camera settings
+- GPS data (if enabled)
+
+## Video Essence (H.264/AVC or H.265/HEVC)
+
+### Supported Codecs
+- **H.264/AVC** (codec name: `avc1`) - Most common
+- **H.265/HEVC** (codec name: `hvc1`) - Also supported
+
+### Frame Structure
+- **Codec**: H.264/AVC High Profile or H.265/HEVC
+- **NAL unit format**: Length-prefixed (4-byte big-endian length + NAL data)
+- **Frames per GOP**: Auto-detected from the first GOP (typically 12), assumed constant throughout file
+
+### Frame Identification
+
+**H.264/AVC frames** begin with an **Access Unit Delimiter (AUD)** NAL:
+```
+00 00 00 02 09 XX
+```
+Where:
+- `00 00 00 02` = NAL length (2 bytes)
+- `09` = NAL type 9 (AUD)
+- `XX` = AUD payload (typically `10` or `30`)
+
+**H.265/HEVC frames** begin with an **Access Unit Delimiter (AUD)** NAL:
+```
+00 00 00 03 46 01 XX
+```
+Where:
+- `00 00 00 03` = NAL length (3 bytes)
+- `46` = First byte of HEVC NAL unit (NAL type 35 = AUD)
+- `01 XX` = AUD payload
+
+### NAL Unit Types Present
+| Type | Name | Description |
+|------|------|-------------|
+| 9 | AUD | Access Unit Delimiter (frame start marker) |
+| 6 | SEI | Supplemental Enhancement Information |
+| 5 | IDR | Instantaneous Decoder Refresh (keyframe slice) |
+| 1 | Non-IDR | Regular slice (P/B frame) |
+
+### Frame Composition
+A typical frame contains:
+1. AUD NAL (2 bytes payload)
+2. SEI NAL(s) (metadata)
+3. Slice NAL(s) (actual video data)
+
+**Keyframe (IDR) example:**
+```
+[AUD len=2][SEI len=19][SEI len=26][SEI len=29][SEI len=14][SEI len=5][IDR slice ×8]
+```
+
+**Inter-frame (P/B) example:**
+```
+[AUD len=2][SEI len=14][Non-IDR slice ×9]
+```
+
+### Important Note on NAL Parsing
+The compressed slice data within NAL units can contain **any byte pattern**, including patterns that look like NAL length prefixes. Do NOT attempt to parse NAL units by reading length fields through slice data. Instead, search for AUD patterns to find frame boundaries.
+
+### GOP Sizes
+The implementation auto-detects `frames_per_gop` by counting AUD patterns in the first GOP (typically 12 frames). It then **assumes** this frame count is consistent throughout the entire file.
+
+**Implementation behavior**:
+- `frames_per_gop` is detected from the first GOP only
+- `audio_chunk_size` is calculated **once** from this detected value and reused for all GOPs
+- Frames are counted individually per GOP (would detect if sizes varied, but doesn't affect audio chunk calculation)
+- The implementation assumes GOP sizes are constant - if they varied, audio chunk size calculation would be incorrect
+
+**Note**: Analysis of one 50GB RSV file (8,655 GOPs) showed all GOPs had exactly 12 frames, but the implementation makes no guarantee about consistency. If GOP sizes varied, the code would need to calculate `audio_chunk_size` per-GOP based on the actual frame count.
+
+## Audio Essence (PCM)
+
+### Format
+- **Codec**: PCM signed 16-bit big-endian (twos/pcm_s16be)
+- **Sample rate**: 48,000 Hz
+- **Channels**: 2 (stereo)
+- **Bits per sample**: 16
+
+### Chunk Structure
+- **Chunk size**: Fixed per file (calculated once from first GOP's frame count)
+- **Samples per chunk**: Calculated as `GOP_duration × sample_rate`
+- **Bytes per sample**: Typically 4 (2 bytes × 2 channels for stereo 16-bit)
+- **Duration per chunk**: Matches GOP duration (assumes constant GOP size)
+
+### Calculation
+Audio chunk size is calculated **once** based on the first GOP's frame count:
+```
+GOP_duration_sec = frames_per_gop / fps
+samples_per_chunk = GOP_duration_sec × audio_sample_rate
+chunk_size = samples_per_chunk × bytes_per_sample
+```
+
+**Example** (12 frames at 25fps, 48kHz stereo 16-bit):
+```
+GOP_duration = 12 frames ÷ 25 fps = 0.480 seconds
+samples_per_chunk = 0.480s × 48000 Hz = 23,040 samples
+chunk_size = 23,040 × 4 bytes = 92,160 bytes
+```
+
+**Important**: The implementation calculates `audio_chunk_size` from the first GOP's `frames_per_gop` and uses this fixed size for all GOPs. It **assumes** GOP sizes are constant throughout the file. If GOP sizes varied, this would cause incorrect audio chunk size calculation. The code counts frames per GOP individually but does not recalculate audio chunk size per GOP.
+
+## Comparison with MP4
+
+### MP4 (Interleaved)
+```
+[ftyp][moov][mdat: V₀ A₀ V₁ A₁ V₂ A₂ ...]
+```
+Video and audio chunks are interleaved within mdat.
+
+### RSV (Block-based)
+```
+[rtmd₀ V₀₋₁₁ A₀][rtmd₁ V₁₂₋₂₃ A₁][rtmd₂ V₂₄₋₃₅ A₂]...
+```
+Each GOP's data is stored as a contiguous block.
+
+## File Identification
+
+### Magic Bytes
+RSV files can be identified by checking offset 0 for the rtmd pattern. The implementation uses a specific header pattern for detection:
+
+```
+Offset 0-7:  00 1c 01 00 23 03 28 e1
+```
+
+This matches the most common rtmd header variant. For more robust detection, verify:
+```
+Offset 0-3:  00 1c 01 00  (prefix)
+Offset 8-11: f0 01 00 10  (Sony tag)
+```
+
+Note: Bytes 4-7 are variable and should not be used for identification. The implementation auto-detects RSV files when this pattern is found at offset 0, or can be forced with the `-rsv` command-line flag.
+
+### No Standard Container
+RSV files lack:
+- `ftyp` atom (file type)
+- `moov` atom (movie metadata)
+- Standard MP4 box structure
+
+The entire file consists of raw GOP blocks.
+
+## Recovery Process
+
+To recover an RSV file using untrunc:
+
+1. **Obtain reference file**: Need a properly-recorded MP4 from the same camera with matching codec parameters (H.264/AVC or H.265/HEVC).
+
+2. **Run untrunc**:
+   ```bash
+   untrunc reference.mp4 corrupt.RSV
+   ```
+   Or explicitly enable RSV mode:
+   ```bash
+   untrunc -rsv reference.mp4 corrupt.RSV
+   ```
+
+3. **Auto-detection**:
+   - RSV files are automatically detected if they start with the rtmd pattern at offset 0
+   - The implementation auto-detects `rtmd_packet_size` by finding the distance between the first two rtmd patterns
+   - The implementation auto-detects `frames_per_gop` by counting AUD patterns in the first GOP
+   - Audio chunk size is calculated **once** from the first GOP's frame count and reused for all GOPs
+
+4. **Parse GOP structure**:
+   - Find rtmd packets by checking both prefix (`001c0100`) AND Sony tag (`f0010010` at offset 8)
+   - Count consecutive rtmd packets (using auto-detected packet size) to find video start
+   - Extract video frames by finding AUD patterns:
+     - H.264: `00 00 00 02 09` (NAL type 9)
+     - HEVC: `00 00 00 03 46` (NAL type 35)
+   - Audio chunk follows immediately after video frames (size calculated from GOP duration)
+
+5. **Build MP4 container**:
+   - Use codec parameters from reference file
+   - Create proper stbl atoms (stco, stsz, stsc, stts, stss, ctts)
+   - Map frame offsets to the RSV data
+
+6. **Handle GOP structure**: 
+   - Count actual AUD patterns per GOP (frames are counted individually)
+   - Count consecutive valid rtmd packets per GOP (rtmd count can vary)
+   - Avoid false positive rtmd matches by verifying the Sony tag at offset 8
+   - **Note**: Audio chunk size is calculated from the first GOP and reused for all GOPs. The implementation assumes GOP sizes are constant throughout the file - if they varied, this would be incorrect.
+
+## Known Cameras
+
+This format has been observed in:
+- Sony FX3
+- Other Sony cameras using XAVC codec
+
+## Typical File Characteristics
+
+| Property | Typical Value |
+|----------|---------------|
+| Video codec | H.264 High Profile or H.265/HEVC |
+| Resolution | 3840×2160 (4K) |
+| Frame rate | 25 fps (variable) |
+| GOP size | Auto-detected from first GOP (typically 12), assumed constant |
+| Audio codec | PCM S16BE (twos/sowt) |
+| Audio rate | 48000 Hz (variable) |
+| Bitrate | ~100 Mbps |
+| rtmd packet size | 19,456 bytes (auto-detected) |
+
+## References
+
+- ITU-T H.264 / ISO/IEC 14496-10 (AVC)
+- ISO/IEC 14496-12 (MP4 container)
+- Sony XAVC format documentation
+
+## Implementation Notes
+
+### Auto-Detection Features
+
+The untrunc implementation includes several auto-detection features:
+
+1. **RSV File Detection**: Automatically detects RSV files by checking for rtmd pattern at offset 0
+2. **rtmd Packet Size**: Auto-detects packet size by measuring distance between first two rtmd patterns
+3. **Frames per GOP**: Auto-detects by counting AUD patterns in the first GOP
+4. **Audio Chunk Size**: Calculated once from the first GOP's frame count and reused for all GOPs (assumes GOP sizes are constant throughout the file)
+5. **Codec Support**: Supports both H.264/AVC (`avc1`) and H.265/HEVC (`hvc1`) codecs
+
+### Command-Line Usage
+
+```bash
+# Auto-detect RSV file
+untrunc reference.mp4 corrupt.RSV
+
+# Force RSV mode
+untrunc -rsv reference.mp4 corrupt.RSV
+```
+
+The `-rsv` flag forces RSV recovery mode even if auto-detection fails.
+
+---
+
+*This documentation was created during the development of RSV recovery support for untrunc. Last updated: November 2025*
+

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -57,6 +57,7 @@ bool g_off_as_hex = true;
 bool g_fast_assert = false;
 bool g_no_ctts = false;
 bool g_is_gui = false;
+bool g_rsv_mode = false;
 uint g_num_w2 = 0;
 Mp4* g_mp4 = nullptr;
 void (*g_onProgress)(int) = nullptr;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -58,6 +58,7 @@ bool g_fast_assert = false;
 bool g_no_ctts = false;
 bool g_is_gui = false;
 bool g_rsv_mode = false;
+bool g_no_rsv_mode = false;
 uint g_num_w2 = 0;
 Mp4* g_mp4 = nullptr;
 void (*g_onProgress)(int) = nullptr;

--- a/src/common.h
+++ b/src/common.h
@@ -37,7 +37,8 @@ extern bool g_interactive, g_muted, g_ignore_unknown, g_stretch_video,
     g_off_as_hex,
     g_fast_assert,
     g_ignore_out_of_bound_chunks, g_skip_existing, g_no_ctts, g_is_gui,
-    g_rsv_mode;
+    g_rsv_mode,
+    g_no_rsv_mode;
 extern int64_t g_range_start, g_range_end;
 extern std::string g_dst_path;
 

--- a/src/common.h
+++ b/src/common.h
@@ -36,7 +36,8 @@ extern bool g_interactive, g_muted, g_ignore_unknown, g_stretch_video,
     g_skip_nal_filler_data,
     g_off_as_hex,
     g_fast_assert,
-    g_ignore_out_of_bound_chunks, g_skip_existing, g_no_ctts, g_is_gui;
+    g_ignore_out_of_bound_chunks, g_skip_existing, g_no_ctts, g_is_gui,
+    g_rsv_mode;
 extern int64_t g_range_start, g_range_end;
 extern std::string g_dst_path;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,7 @@ void usage() {
 	     << "-sm  - search mdat, even if no mp4-structure found\n"
 	     << "-dcc  - dont check if chunks are inside mdat\n"
 	     << "-dyn  - use dynamic stats\n"
+	     << "-rsv  - Sony RSV file recovery mode\n"
 	     << "-range <A:B>  - raw data range\n"
 	     << "-dst <dir|file>  - set destination\n"
 	     << "-skip  - skip existing\n"
@@ -153,6 +154,7 @@ int main(int argc, char *argv[]) {
 			else if (a == "u") unite = true;
 			else if (a == "dcc") g_ignore_out_of_bound_chunks = true;
 			else if (a == "dyn") g_use_chunk_stats = true;
+			else if (a == "rsv") g_rsv_mode = true;
 			else if (a == "range") arg_range = kExpectArg;
 			else if (a == "dst") arg_dst = kExpectArg;
 			else if (a == "skip") g_skip_existing = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@ void usage() {
 	     << "-dcc  - dont check if chunks are inside mdat\n"
 	     << "-dyn  - use dynamic stats\n"
 	     << "-rsv  - Sony RSV file recovery mode\n"
+	     << "-no-rsv  - disable RSV auto-detection\n"
 	     << "-range <A:B>  - raw data range\n"
 	     << "-dst <dir|file>  - set destination\n"
 	     << "-skip  - skip existing\n"
@@ -155,6 +156,7 @@ int main(int argc, char *argv[]) {
 			else if (a == "dcc") g_ignore_out_of_bound_chunks = true;
 			else if (a == "dyn") g_use_chunk_stats = true;
 			else if (a == "rsv") g_rsv_mode = true;
+			else if (a == "no-rsv") g_no_rsv_mode = true;
 			else if (a == "range") arg_range = kExpectArg;
 			else if (a == "dst") arg_dst = kExpectArg;
 			else if (a == "skip") g_skip_existing = true;

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -2532,7 +2532,7 @@ void Mp4::repairRsv(const string& filename) {
 		// Find first rtmd block end (count rtmd packets)
 		int first_rtmd_count = 0;
 		off_t detect_pos = 0;
-		while (detect_pos + 12 < detect_read && first_rtmd_count < 20) {
+		while (detect_pos + 12 < detect_read && first_rtmd_count < 100) {
 			if (memcmp(detect_buf.data() + detect_pos, rtmd_pattern_prefix, 4) == 0 &&
 			    memcmp(detect_buf.data() + detect_pos + 8, rtmd_pattern_sony_tag, 4) == 0) {
 				first_rtmd_count++;
@@ -2601,7 +2601,7 @@ void Mp4::repairRsv(const string& filename) {
 		// Check both prefix (bytes 0-3) and MXF marker (bytes 8-11) to avoid false positives
 		int rtmd_count = 0;
 		uchar rtmd_header[12];
-		while (pos + rtmd_count * rtmd_packet_size < file_size && rtmd_count < 20) {
+		while (pos + rtmd_count * rtmd_packet_size < file_size && rtmd_count < 100) {
 			file_read.seek(pos + rtmd_count * rtmd_packet_size);
 			file_read.readChar((char*)rtmd_header, 12);
 			// Check prefix (001c0100) AND marker at offset 8 (f0010010)

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -2239,6 +2239,23 @@ void Mp4::repair(const string& filename) {
 		return;
 	}
 
+	// Check for RSV mode (explicit or auto-detect)
+	if (g_rsv_mode) {
+		repairRsv(filename);
+		return;
+	}
+	
+	// Auto-detect RSV structure
+	{
+		FileRead file_read(filename);
+		if (detectRsvStructure(file_read)) {
+			logg(I, "auto-detected RSV file, switching to RSV mode\n");
+			g_rsv_mode = true;
+			repairRsv(filename);
+			return;
+		}
+	}
+
 	use_offset_map_ = use_offset_map_ || filename == filename_ok_;
 	if (use_offset_map_) analyze(true);
 
@@ -2359,6 +2376,414 @@ void Mp4::repair(const string& filename) {
 
 	for (auto& track : tracks_) track.fixTimes();
 
+	auto filename_fixed = getPathRepaired(filename_ok_, filename);
+	saveVideo(filename_fixed);
+}
+
+// RSV file detection - check for rtmd pattern at offset 0
+bool Mp4::detectRsvStructure(FileRead& file_read) {
+	// RSV files start with rtmd pattern: 00 1c 01 00 23 03 28 e1
+	const uchar rsv_header[] = {0x00, 0x1c, 0x01, 0x00, 0x23, 0x03, 0x28, 0xe1};
+	
+	file_read.seek(0);
+	uchar buf[8];
+	file_read.readChar((char*)buf, 8);
+	
+	bool is_rsv = memcmp(buf, rsv_header, 8) == 0;
+	if (is_rsv) {
+		logg(I, "detected RSV file structure (Sony recording-in-progress)\n");
+	}
+	return is_rsv;
+}
+
+// RSV file repair - processes GOP-based structure
+void Mp4::repairRsv(const string& filename) {
+	logg(I, "using RSV recovery mode\n");
+	
+	auto& file_read = openFile(filename);
+	
+	// Set up current_mdat_ for the RSV file as if it were an mdat starting at offset 0
+	delete current_mdat_;
+	current_mdat_ = new BufferedAtom(file_read);
+	current_mdat_->name_ = "mdat";
+	current_mdat_->start_ = -8;  // Pretend mdat header is at -8 so content starts at 0
+	current_mdat_->file_end_ = file_read.length();
+	
+	// RSV structure parameters - all auto-detected from RSV file itself
+	// - rtmd_packet_size: distance between consecutive rtmd patterns (fallback: 19456)
+	// - frames_per_gop: count of video frames in first GOP (fallback: 12)
+	int rtmd_packet_size = 19456;
+	int frames_per_gop = 12;
+	
+	// AUD (Access Unit Delimiter) patterns with length prefix
+	// H.264: NAL type 9 (0x09), typically 2-byte payload: 00 00 00 02 09 XX
+	// HEVC:  NAL type 35 (0x23), in 2-byte header: 00 00 00 03 46 01 XX
+	//        HEVC NAL type = (first_byte >> 1) & 0x3F = (0x46 >> 1) & 0x3F = 35
+	const uchar aud_pattern_h264[] = {0x00, 0x00, 0x00, 0x02, 0x09};
+	const uchar aud_pattern_hevc[] = {0x00, 0x00, 0x00, 0x03, 0x46};
+	// aud_pattern will be set after we determine video codec type
+	
+	// rtmd header pattern to find GOP boundaries
+	// Real rtmd packets have:
+	//   - Bytes 0-3: 001c0100 (constant prefix)
+	//   - Bytes 4-7: variable (camera metadata like timestamp)
+	//   - Bytes 8-11: f0010010 (constant Sony tag)
+	// False positives (random video data) match bytes 0-3 but NOT bytes 8-11
+	const uchar rtmd_pattern_prefix[] = {0x00, 0x1c, 0x01, 0x00};
+	const uchar rtmd_pattern_sony_tag[] = {0xf0, 0x01, 0x00, 0x10};  // at offset 8
+	
+	// Find video and audio track indices BEFORE clearing tracks
+	// (clear() wipes out the keyframes_ we need)
+	// Support both H.264 (avc1) and H.265/HEVC (hvc1)
+	int video_track_idx = getTrackIdx2("avc1");
+	bool is_hevc = false;
+	if (video_track_idx < 0) {
+		video_track_idx = getTrackIdx2("hvc1");
+		is_hevc = true;
+	}
+	int audio_track_idx = getTrackIdx2("twos");
+	if (audio_track_idx < 0) audio_track_idx = getTrackIdx2("sowt");
+	
+	if (video_track_idx < 0) {
+		logg(ET, "no video track (avc1/hvc1) found in reference file\n");
+		return;
+	}
+	logg(I, "video track: ", video_track_idx, " (", (is_hevc ? "HEVC" : "H.264"), "), audio track: ", audio_track_idx, "\n");
+	
+	// Select AUD pattern based on codec
+	const uchar* aud_pattern = is_hevc ? aud_pattern_hevc : aud_pattern_h264;
+	
+	// Get audio and video parameters from reference file BEFORE clearing
+	int audio_sample_size = 4;  // default: stereo 16-bit = 4 bytes per sample
+	int audio_sample_rate = 48000;  // default
+	int video_timescale = 25000;    // default (for 25fps)
+	int video_duration_per_sample = 1000;  // default (25fps = 25000/1000)
+	
+	if (video_track_idx >= 0) {
+		Track& video_track = tracks_[video_track_idx];
+		video_timescale = video_track.timescale_;
+		if (!video_track.times_.empty()) {
+			video_duration_per_sample = video_track.times_[0];
+		}
+		logg(V, "video timescale: ", video_timescale, ", duration per sample: ", video_duration_per_sample, "\n");
+		
+		// Note: frames_per_gop will be auto-detected from RSV file itself
+		// (reference file may have different GOP settings than the RSV being recovered)
+	}
+	
+	if (audio_track_idx >= 0) {
+		Track& audio_track = tracks_[audio_track_idx];
+		if (audio_track.constant_size_ > 0) {
+			audio_sample_size = audio_track.constant_size_;
+		}
+		audio_sample_rate = audio_track.timescale_;  // For audio, timescale is sample rate
+		logg(V, "audio sample size: ", audio_sample_size, ", sample rate: ", audio_sample_rate, "\n");
+	}
+	
+	// NOW clear tracks to prepare for RSV parsing
+	duration_ = 0;
+	for (uint i = 0; i < tracks_.size(); i++)
+		tracks_[i].clear();
+	
+	// Get file size
+	off_t file_size = file_read.length();
+	logg(I, "RSV file size: ", file_size, " bytes\n");
+	
+	if (file_size > (1LL<<32)) {
+		broken_is_64_ = true;
+		logg(I, "using 64-bit offsets for the RSV file\n");
+	}
+	
+	// Auto-detect RSV structure parameters from the file itself
+	{
+		vector<uchar> detect_buf(8 * 1024 * 1024);  // 8MB buffer for detection
+		file_read.seek(0);
+		size_t detect_read = min((off_t)detect_buf.size(), file_size);
+		file_read.readChar((char*)detect_buf.data(), detect_read);
+		
+		// First, detect rtmd_packet_size by finding distance between first two rtmd patterns
+		off_t first_rtmd = -1, second_rtmd = -1;
+		for (size_t i = 0; i < min(detect_read, (size_t)100000) - 12; i++) {
+			if (memcmp(detect_buf.data() + i, rtmd_pattern_prefix, 4) == 0 &&
+			    memcmp(detect_buf.data() + i + 8, rtmd_pattern_sony_tag, 4) == 0) {
+				if (first_rtmd < 0) {
+					first_rtmd = i;
+				} else {
+					second_rtmd = i;
+					break;
+				}
+			}
+		}
+		
+		if (first_rtmd >= 0 && second_rtmd > first_rtmd) {
+			int detected_size = second_rtmd - first_rtmd;
+			if (detected_size > 1000 && detected_size < 100000) {  // Sanity check
+				rtmd_packet_size = detected_size;
+				logg(I, "rtmd packet size auto-detected from RSV: ", rtmd_packet_size, " bytes\n");
+			}
+		} else {
+			logg(W, "could not detect rtmd packet size, using default: ", rtmd_packet_size, "\n");
+		}
+		
+		// Now detect frames_per_gop by counting frames in first GOP
+		// Find first rtmd block end (count rtmd packets)
+		int first_rtmd_count = 0;
+		off_t detect_pos = 0;
+		while (detect_pos + 12 < detect_read && first_rtmd_count < 20) {
+			if (memcmp(detect_buf.data() + detect_pos, rtmd_pattern_prefix, 4) == 0 &&
+			    memcmp(detect_buf.data() + detect_pos + 8, rtmd_pattern_sony_tag, 4) == 0) {
+				first_rtmd_count++;
+				detect_pos += rtmd_packet_size;
+			} else {
+				break;
+			}
+		}
+		
+		if (first_rtmd_count > 0) {
+			off_t video_start = first_rtmd_count * rtmd_packet_size;
+			
+			// Find next rtmd block
+			off_t next_rtmd = 0;
+			for (size_t i = video_start + 500 * 1024; i < detect_read - 12; i++) {
+				if (memcmp(detect_buf.data() + i, rtmd_pattern_prefix, 4) == 0 &&
+				    memcmp(detect_buf.data() + i + 8, rtmd_pattern_sony_tag, 4) == 0) {
+					next_rtmd = i;
+					break;
+				}
+			}
+			
+			if (next_rtmd > 0) {
+				// Count AUD patterns between video_start and next_rtmd - audio_chunk_size margin
+				// Use a generous margin for audio
+				off_t video_end_approx = next_rtmd - 100000;  // 100KB margin
+				int aud_count = 0;
+				const uchar* aud_p = is_hevc ? aud_pattern_hevc : aud_pattern_h264;
+				
+				for (size_t i = video_start; i < video_end_approx - 5; i++) {
+					if (memcmp(detect_buf.data() + i, aud_p, 5) == 0) {
+						aud_count++;
+					}
+				}
+				
+				if (aud_count >= 6 && aud_count <= 60) {  // Sanity check
+					frames_per_gop = aud_count;
+					logg(I, "frames per GOP auto-detected from RSV: ", frames_per_gop, "\n");
+				}
+			}
+		}
+	}
+	
+	// Calculate audio chunk size based on GOP duration
+	// GOP duration = frames_per_gop * duration_per_sample / timescale
+	// Audio samples per chunk = GOP duration * audio_sample_rate
+	double fps = (double)video_timescale / video_duration_per_sample;
+	double gop_duration_sec = (double)frames_per_gop / fps;
+	int audio_samples_per_chunk = (int)(gop_duration_sec * audio_sample_rate);
+	int audio_chunk_size = audio_samples_per_chunk * audio_sample_size;
+	
+	logg(I, "derived parameters: fps=", fps, ", GOP duration=", gop_duration_sec, "s, audio chunk=", audio_chunk_size, " bytes\n");
+	
+	// Process file GOP by GOP
+	off_t pos = 0;
+	int gop_count = 0;
+	int total_video_frames = 0;
+	int total_audio_chunks = 0;
+	
+	// Buffer for reading
+	const size_t buf_size = 16 * 1024 * 1024;  // 16MB buffer
+	vector<uchar> buffer(buf_size);
+	
+	while (pos < file_size) {
+		// First, count rtmd packets to skip past them
+		// Check both prefix (bytes 0-3) and MXF marker (bytes 8-11) to avoid false positives
+		int rtmd_count = 0;
+		uchar rtmd_header[12];
+		while (pos + rtmd_count * rtmd_packet_size < file_size && rtmd_count < 20) {
+			file_read.seek(pos + rtmd_count * rtmd_packet_size);
+			file_read.readChar((char*)rtmd_header, 12);
+			// Check prefix (001c0100) AND marker at offset 8 (f0010010)
+			if (memcmp(rtmd_header, rtmd_pattern_prefix, 4) == 0 &&
+			    memcmp(rtmd_header + 8, rtmd_pattern_sony_tag, 4) == 0) {
+				rtmd_count++;
+			} else {
+				break;
+			}
+		}
+		
+		if (rtmd_count == 0) {
+			logg(V, "no rtmd packets found at ", pos, ", ending\n");
+			break;
+		}
+		
+		off_t rtmd_end = pos + rtmd_count * rtmd_packet_size;
+		off_t video_start = rtmd_end;  // Video starts immediately after rtmd block
+		
+		logg(V, "GOP ", gop_count, ": rtmd at ", pos, " (", rtmd_count, " packets), video starts at ", video_start, "\n");
+		
+		// Read buffer starting from video_start for frame detection
+		file_read.seek(video_start);
+		size_t to_read = min((off_t)buf_size, file_size - video_start);
+		file_read.readChar((char*)buffer.data(), to_read);
+		
+		// Find all video frames by searching for AUD patterns
+		// Use memchr for fast first-byte search, then verify remaining bytes
+		vector<off_t> frame_offsets;
+		vector<uint> frame_sizes;
+		
+		// Fast AUD pattern search using memchr
+		// AUD pattern: 00 00 00 02 09
+		const uchar* buf_ptr = buffer.data();
+		const uchar* buf_end = buf_ptr + to_read - 5;
+		const uchar* p = buf_ptr;
+		
+		while (p < buf_end) {
+			// Use memchr to quickly find potential start (first 0x00)
+			p = (const uchar*)memchr(p, 0x00, buf_end - p);
+			if (!p) break;
+			
+			// Verify full pattern: 00 00 00 02 09
+			if (p + 4 < buf_end && p[1] == 0x00 && p[2] == 0x00 && p[3] == 0x02 && p[4] == 0x09) {
+				frame_offsets.push_back(video_start + (p - buf_ptr));
+				p += 5;  // Skip past pattern
+			} else {
+				p++;
+			}
+		}
+		
+		// Find next rtmd block to determine where video region ends
+		// Use memchr for fast search, then verify the Sony tag
+		off_t next_rtmd_start = file_size;
+		size_t min_search_offset = min((size_t)(500 * 1024), to_read / 4);  // At least 500KB in
+		
+		p = buf_ptr + min_search_offset;
+		buf_end = buf_ptr + to_read - 12;
+		
+		while (p < buf_end) {
+			// Fast search for rtmd prefix first byte (0x00)
+			p = (const uchar*)memchr(p, 0x00, buf_end - p);
+			if (!p) break;
+			
+			// Verify prefix: 00 1c 01 00
+			if (p[1] == 0x1c && p[2] == 0x01 && p[3] == 0x00) {
+				// Verify Sony tag at offset 8: f0 01 00 10
+				if (p[8] == 0xf0 && p[9] == 0x01 && p[10] == 0x00 && p[11] == 0x10) {
+					next_rtmd_start = video_start + (p - buf_ptr);
+					break;
+				}
+			}
+			p++;
+		}
+		
+		// Audio is 92160 bytes before next rtmd
+		off_t audio_boundary = next_rtmd_start - audio_chunk_size;
+		
+		// Filter out any frame offsets that are past the audio boundary
+		while (!frame_offsets.empty() && frame_offsets.back() >= audio_boundary) {
+			frame_offsets.pop_back();
+		}
+		
+		// Calculate frame sizes
+		for (size_t i = 0; i < frame_offsets.size(); i++) {
+			if (i + 1 < frame_offsets.size()) {
+				frame_sizes.push_back(frame_offsets[i + 1] - frame_offsets[i]);
+			} else {
+				// Last frame ends at audio boundary
+				frame_sizes.push_back(audio_boundary - frame_offsets[i]);
+			}
+		}
+		
+		// Calculate where video ends (after last frame)
+		off_t video_end = video_start;
+		if (!frame_offsets.empty() && !frame_sizes.empty()) {
+			video_end = frame_offsets.back() + frame_sizes.back();
+		}
+		
+		logg(V, "GOP ", gop_count, ": found ", frame_offsets.size(), " frames, video ends at ", video_end, "\n");
+		
+		// Audio starts after video (at audio_boundary calculated earlier)
+		off_t audio_start = audio_boundary;
+		
+		if (frame_offsets.empty()) {
+			logg(V, "no more video frames found, ending\n");
+			break;
+		}
+		
+		// Process video frames
+		int frames_in_gop = frame_offsets.size();
+		
+		// Frame sizes already calculated during parsing
+		
+		// Add frames to track
+		for (int f = 0; f < frames_in_gop; f++) {
+			off_t frame_off = frame_offsets[f];
+			uint frame_sz = frame_sizes[f];
+			
+			// Determine if keyframe (first frame of GOP is IDR)
+			bool is_keyframe = (f == 0);
+			
+			Track& video_track = tracks_[video_track_idx];
+			video_track.num_samples_++;
+			if (is_keyframe) {
+				video_track.keyframes_.push_back(video_track.sizes_.size());
+			}
+			video_track.sizes_.push_back(frame_sz);
+			
+			// Add chunk info - offsets are relative to file start (mdat content start = 0)
+			Track::Chunk chunk;
+			chunk.off_ = frame_off;  // Will be adjusted in saveVideo
+			chunk.size_ = frame_sz;
+			chunk.n_samples_ = 1;
+			video_track.chunks_.push_back(chunk);
+			
+			total_video_frames++;
+			pkt_idx_++;
+		}
+		
+		logg(V, "GOP ", gop_count, ": ", frames_in_gop, " video frames, audio at ", audio_start, "\n");
+		
+		// Process audio chunk if audio track exists
+		if (audio_track_idx >= 0 && audio_start + audio_chunk_size <= file_size) {
+			Track& audio_track = tracks_[audio_track_idx];
+			
+			// Each audio chunk contains multiple PCM samples
+			// 92160 bytes / 4 bytes per sample = 23040 samples
+			int samples_in_chunk = audio_chunk_size / audio_sample_size;
+			audio_track.num_samples_ += samples_in_chunk;
+			
+			// Add chunk
+			Track::Chunk audio_chunk;
+			audio_chunk.off_ = audio_start;
+			audio_chunk.size_ = audio_chunk_size;
+			audio_chunk.n_samples_ = samples_in_chunk;
+			audio_track.chunks_.push_back(audio_chunk);
+			
+			total_audio_chunks++;
+			pkt_idx_ += samples_in_chunk;
+			
+			// Next GOP starts after audio
+			pos = audio_start + audio_chunk_size;
+		} else {
+			// No audio or end of file
+			pos = audio_start;
+		}
+		
+		gop_count++;
+		
+		// Progress indicator
+		if (gop_count % 10 == 0) {
+			outProgress(pos, file_size);
+		}
+	}
+	
+	logg(I, "\nRSV recovery complete:\n");
+	logg(I, "  GOPs processed: ", gop_count, "\n");
+	logg(I, "  Video frames: ", total_video_frames, "\n");
+	logg(I, "  Audio chunks: ", total_audio_chunks, "\n");
+	
+	// Fix track timing
+	for (auto& track : tracks_) track.fixTimes();
+	
+	// Save the recovered video
 	auto filename_fixed = getPathRepaired(filename_ok_, filename);
 	saveVideo(filename_fixed);
 }

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -2499,7 +2499,7 @@ void Mp4::repairRsv(const string& filename) {
 	
 	// Auto-detect RSV structure parameters from the file itself
 	{
-		vector<uchar> detect_buf(8 * 1024 * 1024);  // 8MB buffer for detection
+		vector<uchar> detect_buf(16 * 1024 * 1024);  // 16MB buffer for detection (GOPs can be 11MB+)
 		file_read.seek(0);
 		size_t detect_read = min((off_t)detect_buf.size(), file_size);
 		file_read.readChar((char*)detect_buf.data(), detect_read);

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -570,6 +570,7 @@ string Mp4::getOutputSuffix() {
 	if (g_use_chunk_stats) output_suffix += "-dyn";
 	if (g_dont_exclude) output_suffix += "-k";
 	if (g_stretch_video) output_suffix += "-sv";
+	if (g_rsv_mode) output_suffix += "-rsv";
 	return output_suffix;
 }
 
@@ -2245,8 +2246,8 @@ void Mp4::repair(const string& filename) {
 		return;
 	}
 	
-	// Auto-detect RSV structure
-	{
+	// Auto-detect RSV structure (unless disabled with -no-rsv)
+	if (!g_no_rsv_mode) {
 		FileRead file_read(filename);
 		if (detectRsvStructure(file_read)) {
 			logg(I, "auto-detected RSV file, switching to RSV mode\n");

--- a/src/mp4.h
+++ b/src/mp4.h
@@ -91,6 +91,10 @@ public:
 	void analyze(bool gen_off_map=false);
 	void repair(const std::string& filename);
 
+	// RSV file recovery
+	bool detectRsvStructure(FileRead& file_read);
+	void repairRsv(const std::string& filename);
+
 	bool wouldMatch(const WouldMatchCfg& cfg);
 	bool wouldMatch2(const uchar* start);
 	bool wouldMatchDyn(off_t offset, int last_idx);


### PR DESCRIPTION
Adds support for recovering Sony RSV files (incomplete/corrupted video files created when recording is interrupted).

Features:
- Auto-detection of RSV files by rtmd pattern
- Support for H.264/AVC and H.265/HEVC codecs
- Auto-detection of rtmd packet size and GOP structure
- Dynamic audio chunk size calculation
- -rsv flag for explicit RSV mode

Includes comprehensive documentation in RSV_FILE_FORMAT.md.