### PR TITLE
file.h: add missing header for Apple

### DIFF
--- a/src/file.h
+++ b/src/file.h
@@ -29,6 +29,10 @@ extern "C" {
 #include <vector>
 #include <string>
 
+#ifdef __APPLE__
+#include <sys/types.h> /* ssize_t */
+#endif
+
 #include "common.h"
 
 class FileRead {


### PR DESCRIPTION
Some macOS versions require `sys/types.h` for `ssize_t` to be available. This fixes build error.