### PR TITLE
Update FFCodec structure for ffmpeg 7.1+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ else ifeq ($(TARGET), $(_EXE)-41)
 else ifeq ($(TARGET), $(_EXE)-60)
 	FF_VER := 6.0
 	EXE := $(TARGET)
+else ifeq ($(TARGET), $(_EXE)-70)
+	FF_VER := 7.0
+	EXE := $(TARGET)
+else ifeq ($(TARGET), $(_EXE)-71)
+	FF_VER := 7.1
+	EXE := $(TARGET)
 endif
 
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,8 @@ ifneq ($(FF_VER), shared)
 	FF_MAJOR_VER := $(word 1, $(subst ., ,$(FF_VER)))
 	ifeq ($(shell test $(FF_MAJOR_VER) -lt 4; echo $$?),0)
 		EXTRA_FF_OPTS := --disable-vda
+	else ifeq ($(shell test $(FF_MAJOR_VER) -gt 6; echo $$?),0)
+		EXTRA_FF_OPTS := --disable-libdrm
 	endif
 else
 	EXTRA_FF_OPTS :=

--- a/src/ff_internal.h
+++ b/src/ff_internal.h
@@ -18,7 +18,9 @@ typedef struct FFCodec {
     int (*update_thread_context_for_user)(struct AVCodecContext *dst,
                                             const struct AVCodecContext *src);
     const FFCodecDefault *defaults;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 13, 100)
     void (*init_static_data)(struct FFCodec *codec);
+#endif
     int (*init)(struct AVCodecContext *);
     union {
         int (*decode)(struct AVCodecContext *avctx, struct AVFrame *frame,


### PR DESCRIPTION
### Short version
It looks like a field was removed above the union in FFCodec, which seems to have broken things quite a bit.

There wasn't an internal version change for this, so there are a handful of commits that this will still break against, but it should be fine against all release versions.

Specifically, the internal version was bumped to 13 in [this ffmpeg commit](https://github.com/FFmpeg/FFmpeg/commit/3305767560a6303f474fffa3afb10c500059b455), and and `init_static_data` was actually removed [a few commits later](https://github.com/FFmpeg/FFmpeg/commit/4524d527bf).

I've also added targets for 7.x releases to the Makefile, and added `--disable-libdrm` to the build flags for versions > 6, because I was getting build errors from the drm bits, and it seemed unlikely that we needed that bit just based on the name (and it still works on my test videos, at least).

### Background
I tried to build this `untrunc` against my Ubuntu shared libraries, which has ffmpeg 7.1, and it didn't work very well at all - recovered a few seconds of a video, if it worked at all. So I tried building the original version, and it worked fine.

After some investigation, I determined that the likely difference was that the original had a baked-in version of ffmpeg. And indeed, building this fork of `untrunc` with various ffmpeg versions worked just fine. After some bisecting of releases I determined that the problem was introduced between 7.0 and 7.1, and then further bisecting with the git repo pointed to the above commit (4524d527bf), where a field was removed from `FFCodec`.

I don't know enough about how all this works to know for sure what effect that had, but I know enough about how C works to suspect that having our copy of the internal headers differ from the _actual_ internal headers is likely to cause all kinds of strange problems. So I made that field conditional on the internal `AVCODEC_VERSION` (as closely as I could), and now `untrunc` runs with 7.1 just fine - both my shared libraries, and the release version.

I don't have a clear enough understanding of everything involved to know if this is the _best_ fix for this or not, but it does seem to fix the issue for me, it's a very simple change, and seems safe as it's quite unlikely to affect building with previous versions of ffmpeg due to the version gating involved.