### PR TITLE
Add builds for ffmpeg 8.0 and 8.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ ifeq ($(NJOBS), 0)
 	NJOBS = 1
 endif
 
-CONFIG_FLAGS := --disable-doc \
+FF_CONFIG_FLAGS := --disable-doc \
 	--disable-everything --enable-decoders --disable-vdpau --enable-demuxers --enable-protocol=file \
 	--disable-avdevice --disable-swresample --disable-swscale --disable-avfilter \
 	--disable-xlib --disable-vaapi --disable-zlib --disable-bzlib --disable-lzma \
@@ -118,15 +118,15 @@ ifneq ($(FF_VER), shared)
 
 	# Flags that have been removed
 	ifeq ($(shell test $(FF_MAJOR_VER) -lt 4; echo $$?),0)
-		CONFIG_FLAGS += --disable-vda
+		FF_CONFIG_FLAGS += --disable-vda
 	endif
 	ifeq ($(shell test $(FF_MAJOR_VER) -lt 8; echo $$?),0)
-		CONFIG_FLAGS += --disable-postproc
+		FF_CONFIG_FLAGS += --disable-postproc
 	endif
 
 	# Flags that have been added
 	ifeq ($(shell test $(FF_MAJOR_VER) -gt 6; echo $$?),0)
-		CONFIG_FLAGS += --disable-libdrm
+		FF_CONFIG_FLAGS += --disable-libdrm
 	endif
 endif
 
@@ -155,7 +155,7 @@ endif
 
 $(FFDIR)/config.asm: | $(FFDIR)/configure
 	@echo "(info) please wait ..."
-	cd $(FFDIR); ./configure $(CONFIG_FLAGS)
+	cd $(FFDIR); ./configure $(FF_CONFIG_FLAGS)
 
 $(FFDIR)/libavcodec/libavcodec.a: | $(FFDIR)/config.asm
 	cat $(FFDIR)/Makefile

--- a/Makefile
+++ b/Makefile
@@ -41,18 +41,18 @@ else
 	_OS := $(shell uname)
 endif
 
-FFDIR := ffmpeg-$(FF_VER)
+FF_DIR := ffmpeg-$(FF_VER)
 
 ifeq ($(FF_VER), shared)
 	CXXFLAGS += -isystem/usr/include/ffmpeg
 	LDFLAGS += -lavformat -lavcodec -lavutil
 else
-	CXXFLAGS += -isystem./$(FFDIR)
-	LDFLAGS += -L$(FFDIR)/libavformat -lavformat
-	LDFLAGS += -L$(FFDIR)/libavcodec -lavcodec
-	LDFLAGS += -L$(FFDIR)/libavutil -lavutil
-	#LDFLAGS += -L$(FFDIR)/libswscale/ -lswresample
-	#LDFLAGS += -L$(FFDIR)/libavresample -lavresample
+	CXXFLAGS += -isystem./$(FF_DIR)
+	LDFLAGS += -L$(FF_DIR)/libavformat -lavformat
+	LDFLAGS += -L$(FF_DIR)/libavcodec -lavcodec
+	LDFLAGS += -L$(FF_DIR)/libavutil -lavutil
+	#LDFLAGS += -L$(FF_DIR)/libswscale/ -lswresample
+	#LDFLAGS += -L$(FF_DIR)/libavresample -lavresample
 	#LDFLAGS += -lz -lbz2 -lX11 -lva -lva-drm -lva-x11 -llzma
 	LDFLAGS += -lpthread -ldl
 
@@ -142,31 +142,31 @@ CURL := $(shell command -v curl 2>/dev/null)
 
 all: $(EXE)
 
-$(FFDIR)/configure:
+$(FF_DIR)/configure:
 	@#read -p "Press [ENTER] if you agree to build ffmpeg-${FF_VER} now.. " input
-	@echo "(info) downloading $(FFDIR) ..."
+	@echo "(info) downloading $(FF_DIR) ..."
 ifdef CURL
-	curl -o /tmp/$(FFDIR).tar.xz https://www.ffmpeg.org/releases/$(FFDIR).tar.xz
+	curl -o /tmp/$(FF_DIR).tar.xz https://www.ffmpeg.org/releases/$(FF_DIR).tar.xz
 else
-	wget -q --show-progress -O /tmp/$(FFDIR).tar.xz https://www.ffmpeg.org/releases/$(FFDIR).tar.xz
+	wget -q --show-progress -O /tmp/$(FF_DIR).tar.xz https://www.ffmpeg.org/releases/$(FF_DIR).tar.xz
 endif
-	tar xf /tmp/$(FFDIR).tar.xz
-	mv $(FFDIR)/VERSION $(FFDIR)/VERSION.bak
+	tar xf /tmp/$(FF_DIR).tar.xz
+	mv $(FF_DIR)/VERSION $(FF_DIR)/VERSION.bak
 
-$(FFDIR)/config.asm: | $(FFDIR)/configure
+$(FF_DIR)/config.asm: | $(FF_DIR)/configure
 	@echo "(info) please wait ..."
-	cd $(FFDIR); ./configure $(FF_CONFIG_FLAGS)
+	cd $(FF_DIR); ./configure $(FF_CONFIG_FLAGS)
 
-$(FFDIR)/libavcodec/libavcodec.a: | $(FFDIR)/config.asm
-	cat $(FFDIR)/Makefile
-	$(MAKE) -C $(FFDIR) -j$(NJOBS)
+$(FF_DIR)/libavcodec/libavcodec.a: | $(FF_DIR)/config.asm
+	cat $(FF_DIR)/Makefile
+	$(MAKE) -C $(FF_DIR) -j$(NJOBS)
 
-$(FFDIR):
+$(FF_DIR):
 ifneq ($(FF_VER), shared)
-$(FFDIR): | $(FFDIR)/libavcodec/libavcodec.a
+$(FF_DIR): | $(FF_DIR)/libavcodec/libavcodec.a
 endif
 
-print_info: | $(FFDIR)
+print_info: | $(FF_DIR)
 	@echo untrunc: $(VER)
 	@echo ffmpeg: $(FF_VER)
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,12 @@ else ifeq ($(TARGET), $(_EXE)-41)
 else ifeq ($(TARGET), $(_EXE)-60)
 	FF_VER := 6.0
 	EXE := $(TARGET)
+else ifeq ($(TARGET), $(_EXE)-70)
+	FF_VER := 7.0
+	EXE := $(TARGET)
+else ifeq ($(TARGET), $(_EXE)-71)
+	FF_VER := 7.1
+	EXE := $(TARGET)
 endif
 
 ifeq ($(OS),Windows_NT)

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,8 @@ ifneq ($(FF_VER), shared)
 	FF_MAJOR_VER := $(word 1, $(subst ., ,$(FF_VER)))
 	ifeq ($(shell test $(FF_MAJOR_VER) -lt 4; echo $$?),0)
 		EXTRA_FF_OPTS := --disable-vda
+	else ifeq ($(shell test $(FF_MAJOR_VER) -gt 6; echo $$?),0)
+		EXTRA_FF_OPTS := --disable-libdrm
 	endif
 else
 	EXTRA_FF_OPTS :=

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,12 @@ else ifeq ($(TARGET), $(_EXE)-70)
 else ifeq ($(TARGET), $(_EXE)-71)
 	FF_VER := 7.1
 	EXE := $(TARGET)
+else ifeq ($(TARGET), $(_EXE)-80)
+	FF_VER := 8.0
+	EXE := $(TARGET)
+else ifeq ($(TARGET), $(_EXE)-81)
+	FF_VER := 8.1
+	EXE := $(TARGET)
 endif
 
 ifeq ($(OS),Windows_NT)
@@ -101,15 +107,27 @@ ifeq ($(NJOBS), 0)
 	NJOBS = 1
 endif
 
+CONFIG_FLAGS := --disable-doc \
+	--disable-everything --enable-decoders --disable-vdpau --enable-demuxers --enable-protocol=file \
+	--disable-avdevice --disable-swresample --disable-swscale --disable-avfilter \
+	--disable-xlib --disable-vaapi --disable-zlib --disable-bzlib --disable-lzma \
+	--disable-audiotoolbox --disable-videotoolbox
+
 ifneq ($(FF_VER), shared)
 	FF_MAJOR_VER := $(word 1, $(subst ., ,$(FF_VER)))
+
+	# Flags that have been removed
 	ifeq ($(shell test $(FF_MAJOR_VER) -lt 4; echo $$?),0)
-		EXTRA_FF_OPTS := --disable-vda
-	else ifeq ($(shell test $(FF_MAJOR_VER) -gt 6; echo $$?),0)
-		EXTRA_FF_OPTS := --disable-libdrm
+		CONFIG_FLAGS += --disable-vda
 	endif
-else
-	EXTRA_FF_OPTS :=
+	ifeq ($(shell test $(FF_MAJOR_VER) -lt 8; echo $$?),0)
+		CONFIG_FLAGS += --disable-postproc
+	endif
+
+	# Flags that have been added
+	ifeq ($(shell test $(FF_MAJOR_VER) -gt 6; echo $$?),0)
+		CONFIG_FLAGS += --disable-libdrm
+	endif
 endif
 
 #$(info $$OBJ is [${OBJ}])
@@ -137,11 +155,7 @@ endif
 
 $(FFDIR)/config.asm: | $(FFDIR)/configure
 	@echo "(info) please wait ..."
-	cd $(FFDIR); ./configure --disable-doc --disable-programs \
-	--disable-everything --enable-decoders --disable-vdpau --enable-demuxers --enable-protocol=file \
-	--disable-avdevice --disable-swresample --disable-swscale --disable-avfilter --disable-postproc \
-	--disable-xlib --disable-vaapi --disable-zlib --disable-bzlib --disable-lzma \
-	--disable-audiotoolbox --disable-videotoolbox $(EXTRA_FF_OPTS)
+	cd $(FFDIR); ./configure $(CONFIG_FLAGS)
 
 $(FFDIR)/libavcodec/libavcodec.a: | $(FFDIR)/config.asm
 	cat $(FFDIR)/Makefile

--- a/src/ff_internal.h
+++ b/src/ff_internal.h
@@ -18,7 +18,9 @@ typedef struct FFCodec {
     int (*update_thread_context_for_user)(struct AVCodecContext *dst,
                                             const struct AVCodecContext *src);
     const FFCodecDefault *defaults;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(61, 13, 100)
     void (*init_static_data)(struct FFCodec *codec);
+#endif
     int (*init)(struct AVCodecContext *);
     union {
         int (*decode)(struct AVCodecContext *avctx, struct AVFrame *frame,


### PR DESCRIPTION
This also reworks the config flags, because 8.0 removed `postproc`, and it was gonna get a little messy, and then also renames `FFDIR` -> `FF_DIR` because that seems more consistent.