### PR TITLE
rsv-ben: fix fps detection for CFR reference clips

### DIFF
--- a/src/rsv.cpp
+++ b/src/rsv.cpp
@@ -103,7 +103,14 @@ void Mp4::repairRsvBen(const string& filename) {
 	if (video_track_idx >= 0) {
 		Track& video_track = tracks_[video_track_idx];
 		video_timescale = video_track.timescale_;
-		if (!video_track.times_.empty()) {
+		// CFR reference clips (all Sony cameras) collapse stts into
+		// constant_duration_ and leave times_ empty. Must read it, otherwise
+		// video_duration_per_sample keeps its 1000 default -> fps wrongly 24
+		// instead of 23.976 (24000/1001) -> audio chunk size off by ~96
+		// bytes/GOP -> 1 corrupt video frame/GOP + short audio.
+		if (video_track.constant_duration_ != -1) {
+			video_duration_per_sample = video_track.constant_duration_;
+		} else if (!video_track.times_.empty()) {
 			video_duration_per_sample = video_track.times_[0];
 		}
 		logg(V, "video timescale: ", video_timescale, ", duration per sample: ", video_duration_per_sample, "\n");
@@ -216,7 +223,12 @@ void Mp4::repairRsvBen(const string& filename) {
 	// Audio samples per chunk = GOP duration * audio_sample_rate
 	double fps = (double)video_timescale / video_duration_per_sample;
 	double gop_duration_sec = (double)frames_per_gop / fps;
-	int audio_samples_per_chunk = (int)(gop_duration_sec * audio_sample_rate);
+	// Exact integer rational: samples = frames_per_gop * sample_rate *
+	// dur_per_sample / timescale (rounded). Avoids float truncation that
+	// would drop a sample and re-introduce the boundary error.
+	int audio_samples_per_chunk = (int)(
+		((long long)frames_per_gop * audio_sample_rate * video_duration_per_sample
+		 + video_timescale / 2) / video_timescale);
 	int audio_chunk_size_per_track = audio_samples_per_chunk * audio_sample_size;
 	// Total audio size in RSV is for all tracks combined
 	int total_audio_chunk_size = audio_chunk_size_per_track * max(1, num_audio_tracks);


### PR DESCRIPTION
## Problem

`-rsv-ben` recovery of Sony recording-in-progress (`.RSV`) files produces, for NTSC-fractional footage (23.976 / 29.97 / 59.94 fps):

- **one corrupt video frame per GOP** — visible as a hitch roughly every half-second, and
- **audio that ends short of the video** (~4.5 s over a 75-minute clip).

This looks like an inherent limitation of recovering an unfinalized file, so it's easy to misattribute as unavoidable data loss. It is not — the frame data is intact in the `.RSV`; it is mis-spliced.

## Root cause

`repairRsvBen()` derives the video frame duration only from `Track::times_`:

```cpp
if (!video_track.times_.empty())
    video_duration_per_sample = video_track.times_[0];
```

But `Track::getSampleTimes()` collapses a single-entry (constant-rate) `stts` into `constant_duration_` and leaves `times_` **empty**:

```cpp
if (entries == 1 && nsamples1 > 500) {
    constant_duration_ = stts->readInt(12);   // times_ stays empty
}
```

Every Sony camera records CFR, so the reference clip's `times_` is empty and `video_duration_per_sample` keeps its `1000` default. `fps` is then computed as `24000 / 1000 = 24` instead of the true `24000 / 1001 = 23.976`.

That feeds the per-GOP audio chunk size:

```
audio_samples_per_chunk = gop_duration_sec * audio_sample_rate
```

giving `12 / 24 * 48000 = 24000` samples (96000 bytes) instead of the correct `12 * 48000 * 1001 / 24000 = 24024` samples (**96096 bytes**) — off by ~96 bytes per GOP. `audio_boundary = next_rtmd_start - total_audio_chunk_size` is then ~96 bytes too late, so the last video frame of every GOP swallows ~96 bytes of PCM (corrupt frame), and the audio chunk is ~96 bytes short every GOP (cumulative drift).

Empirically confirmed on a 58 GB FX30 XAVC S `.RSV`: at the 96096-byte boundary the bytes before are high-entropy H.264 and after are low-amplitude 16-bit PCM; at 96000 both sides are PCM.

## Fix

- Read `constant_duration_` when `times_` is empty (the actual fix).
- Compute `audio_samples_per_chunk` with exact integer rounding so float truncation cannot drop a sample at other rates.

## Verification

Patched build, same 58 GB FX30 `.RSV` + a same-codec CFR reference:

- `derived parameters: fps=23.976, GOP duration=0.5005s, audio chunk=96096 bytes` (was `fps=24 … 96000`)
- `Duration of avc1` and `Duration of twos` now identical (were 4.5 s apart)
- continuous decode: **0 per-GOP errors** (was ~1 corrupt frame per 12-frame GOP); only the genuinely truncated final ~2 s (point of recording interruption) is damaged.
